### PR TITLE
Id's not being recognized by mongodb 3.x unless in native formate

### DIFF
--- a/lib/clients/mongoclient.js
+++ b/lib/clients/mongoclient.js
@@ -47,7 +47,7 @@ class MongoClient extends DatabaseClient {
 
             var db = that._mongo.collection(collection);
             var query = {_id: id};
-            query = setupId(query);
+            query = that.setupId(query);
             db.deleteOne(query, {w:1}, function (error, result) {
                 if (error) return reject(error);
                 return resolve(result.deletedCount);
@@ -59,7 +59,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
-            query = setupId(query);
+            query = that.setupId(query);
             db.deleteOne(query, {w:1}, function (error, result) {
                 if (error) return reject(error);
                 return resolve(result.deletedCount);
@@ -71,7 +71,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
-            query = setupId(query);
+            query = that.setupId(query);
             db.deleteMany(query, {w:1}, function (error, result) {
                 if (error) return reject(error);
                 return resolve(result.deletedCount);
@@ -83,7 +83,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
-            query = setupId(query);
+            query = that.setupId(query);
             db.findOne(query, function (error, doc) {
                 if (error) return reject(error);
                 return resolve(doc);
@@ -110,7 +110,7 @@ class MongoClient extends DatabaseClient {
             } else {
                 update = { $set: update };
             }
-            query = setupId(query);
+            query = that.setupId(query);
             db.findOneAndUpdate(query, update, options, function(error, result) {
                 if (error) return reject(error);
                 resolve(result.value);
@@ -139,7 +139,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
-            query = setupId(query);
+            query = that.setupId(query);
             db.find(query).toArray(function (error, docs) {
                 if (error) return reject(error);
                 return resolve(docs);
@@ -151,7 +151,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
-            query = setupId(query);
+            query = that.setupId(query);
             db.count(query, function (error, count) {
                 if (error) return reject(error);
                 return resolve(count);
@@ -209,7 +209,7 @@ class MongoClient extends DatabaseClient {
         return value instanceof ObjectId || String(value).match(/^[a-fA-F0-9]{24}$/);
     }
 
-    setupID(query) {
+    setupId(query) {
       if(query.id && !(query.id instanceof ObjectId)){
         query.id = ObjectId(query.id);
       }

--- a/lib/clients/mongoclient.js
+++ b/lib/clients/mongoclient.js
@@ -46,7 +46,9 @@ class MongoClient extends DatabaseClient {
             if (id === null) resolve(0);
 
             var db = that._mongo.collection(collection);
-            db.deleteOne({ _id: id }, {w:1}, function (error, result) {
+            var query = {_id: id};
+            query = setupId(query);
+            db.deleteOne(query, {w:1}, function (error, result) {
                 if (error) return reject(error);
                 return resolve(result.deletedCount);
             });
@@ -57,6 +59,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
+            query = setupId(query);
             db.deleteOne(query, {w:1}, function (error, result) {
                 if (error) return reject(error);
                 return resolve(result.deletedCount);
@@ -68,6 +71,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
+            query = setupId(query);
             db.deleteMany(query, {w:1}, function (error, result) {
                 if (error) return reject(error);
                 return resolve(result.deletedCount);
@@ -79,11 +83,12 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
+            query = setupId(query);
             db.findOne(query, function (error, doc) {
                 if (error) return reject(error);
                 return resolve(doc);
             });
-        });
+        }.bind(this));
     }
 
     loadOneAndUpdate(collection, query, values, options) {
@@ -105,7 +110,7 @@ class MongoClient extends DatabaseClient {
             } else {
                 update = { $set: update };
             }
-
+            query = setupId(query);
             db.findOneAndUpdate(query, update, options, function(error, result) {
                 if (error) return reject(error);
                 resolve(result.value);
@@ -134,6 +139,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
+            query = setupId(query);
             db.find(query).toArray(function (error, docs) {
                 if (error) return reject(error);
                 return resolve(docs);
@@ -145,6 +151,7 @@ class MongoClient extends DatabaseClient {
         var that = this;
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
+            query = setupId(query);
             db.count(query, function (error, count) {
                 if (error) return reject(error);
                 return resolve(count);
@@ -200,6 +207,16 @@ class MongoClient extends DatabaseClient {
 
     isNativeId(value) {
         return value instanceof ObjectId || String(value).match(/^[a-fA-F0-9]{24}$/);
+    }
+
+    setupID(query) {
+      if(query.id && !(query.id instanceof ObjectId)){
+        query.id = ObjectId(query.id);
+      }
+      if(query._id && !(query._id instanceof ObjectId)){
+        query._id = ObjectId(query._id);
+      }
+      return query;
     }
 
     nativeIdType() {


### PR DESCRIPTION
With mongodb 3.x the requirement that _id be in ObjectId format is hard. This pull request checks a query for an _id that is not in Native format and makes it native.