### PR TITLE
Start of Typescript typing file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,9 +22,9 @@ declare module 'camo' {
 
         validate();
 
-        create(data: any): BaseDocument;
+        create(data: any): this;
         populate(): Promise<{}>;
-        static populate(docs: BaseDocument | BaseDocument[]): Promise<BaseDocument | BaseDocument[]>;
+        static populate(docs: this | this[]): Promise<this | this[]>;
         getDefault(schemaProp: string): any;
     }
 
@@ -37,15 +37,15 @@ declare module 'camo' {
         static deleteMany(query: CamoQuery): Promise<{}>;
         static loadOne(query: CamoQuery, options?: {
             populate?: boolean,
-        }): Promise<Document>;
+        }): Promise<this;
         static loadOneAndUpdate(query: CamoQuery, values: any, options?: {
             populate?: boolean,
             upsert?: boolean,
-        }): Promise<Document>;
-        static loadOneAndDelete(query: CamoQuery, options?: {}): Promise<Document>;
+        }): Promise<this>;
+        static loadOneAndDelete(query: CamoQuery, options?: {}): Promise<this>;
         static loadMany(query: CamoQuery, options?: {
             populate?: boolean,
-        }): Promise<Document[]>;
+        }): Promise<this[]>;
         static count(query: CamoQuery): Promise<number>;
         static clearCollection(): Promise<{}>;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,8 @@ declare module 'camo' {
 
         create(data: any): this;
         populate(): Promise<{}>;
-        static populate(docs: this | this[]): Promise<this | this[]>;
+        static populate<T>(docs: T): Promise<T>;
+        static potulate<T>(docs: T[]): Promise<T[]>;
         getDefault(schemaProp: string): any;
     }
 
@@ -35,17 +36,17 @@ declare module 'camo' {
         delete(): Promise<{}>;
         static deleteOne(query: CamoQuery): Promise<{}>;
         static deleteMany(query: CamoQuery): Promise<{}>;
-        static loadOne(query: CamoQuery, options?: {
+        static loadOne<T>(query: CamoQuery, options?: {
             populate?: boolean,
-        }): Promise<this;
-        static loadOneAndUpdate(query: CamoQuery, values: any, options?: {
+        }): Promise<T>;
+        static loadOneAndUpdate<T>(query: CamoQuery, values: any, options?: {
             populate?: boolean,
             upsert?: boolean,
-        }): Promise<this>;
-        static loadOneAndDelete(query: CamoQuery, options?: {}): Promise<this>;
-        static loadMany(query: CamoQuery, options?: {
+        }): Promise<T>;
+        static loadOneAndDelete<T>(query: CamoQuery, options?: {}): Promise<T>;
+        static loadMany<T>(query: CamoQuery, options?: {
             populate?: boolean,
-        }): Promise<this[]>;
+        }): Promise<T[]>;
         static count(query: CamoQuery): Promise<number>;
         static clearCollection(): Promise<{}>;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,56 @@
+declare module 'camo' {
+    type CamoQuery = any;
+    type CamoDatabase = any;
+
+    export function connect(uri: string): Promise<CamoDatabase>;
+
+    export interface CamoMetadata {
+        collection: string;
+    }
+
+    export abstract class BaseDocument {
+        constructor();
+        schema(definition: any);
+
+        // hooks
+        //preValidate();
+        //postValidate();
+        //preSave();
+        //postSave();
+        //preDelete();
+        //postDelete();
+
+        validate();
+
+        create(data: any): BaseDocument;
+        populate(): Promise<{}>;
+        static populate(docs: BaseDocument | BaseDocument[]): Promise<BaseDocument | BaseDocument[]>;
+        getDefault(schemaProp: string): any;
+    }
+
+    export class Document extends BaseDocument {
+        constructor(name: string);
+        meta: CamoMetadata;
+        save(): Promise<{}>;
+        delete(): Promise<{}>;
+        static deleteOne(query: CamoQuery): Promise<{}>;
+        static deleteMany(query: CamoQuery): Promise<{}>;
+        static loadOne(query: CamoQuery, options?: {
+            populate?: boolean,
+        }): Promise<Document>;
+        static loadOneAndUpdate(query: CamoQuery, values: any, options?: {
+            populate?: boolean,
+            upsert?: boolean,
+        }): Promise<Document>;
+        static loadOneAndDelete(query: CamoQuery, options?: {}): Promise<Document>;
+        static loadMany(query: CamoQuery, options?: {
+            populate?: boolean,
+        }): Promise<Document[]>;
+        static count(query: CamoQuery): Promise<number>;
+        static clearCollection(): Promise<{}>;
+    }
+
+    export class EmbeddedDocument extends BaseDocument {
+        constructor();
+    }
+}


### PR DESCRIPTION
This is the start of a typescript typing file. I'm not sure if this is something you would be interesting keeping in the main repository or not. I think it would be useful for myself and fellow Typescript developers (Typescript now supports lookup of typing information from `node_modules`). It also can be useful for non-Typescript developers. (Editors like Visual Studio Code and Atom can use Typescript definitions to provide better IDE support for JavaScript as well.)

Reasons it is not yet complete/a work in progress:

- More `any` typed things that I would prefer
- Just supports the root import and not sub-imports (`import * as db from 'camo/db'` for instance)
- Doesn't yet have every class or option
- Could use JSDoc comments (ie, copy them from the rest of the project)
- Maybe want Typescript test file too (DefinitelyTyped requires them now on every type definition file these days, which is why I'm contributing less to that monster repo these days)

Anyway, I think this is interesting/useful enough even in this basic state for others to maybe utilize so I'm submitting it as a PR if are interesting in merging it into the repo.
