### PR TITLE
Support to exclude methods when extracting toJSON()

### DIFF
--- a/lib/base-document.js
+++ b/lib/base-document.js
@@ -37,6 +37,7 @@ class BaseDocument {
             _id: { type: DB().nativeIdType() },     // Native ID to backend database
         };
 
+        this._extractDocPropertiesOnly = null;
         this._id = null;
     }
 
@@ -481,10 +482,13 @@ class BaseDocument {
         }
         var proto = Object.getPrototypeOf(this);
         var protoProps = Object.getOwnPropertyNames(proto);
-        for (var i = 0; i < protoProps.length; i++) {
-            key = protoProps[i];
-            if (key !== 'constructor' && key !== 'id'){
-                values[key] = this[key];
+
+        if (this._extractDocPropertiesOnly !== true) {
+            for (var i = 0; i < protoProps.length; i++) {
+                key = protoProps[i];
+                if (key !== 'constructor' && key !== 'id') {
+                    values[key] = this[key];
+                }
             }
         }
         return values;

--- a/lib/base-document.js
+++ b/lib/base-document.js
@@ -480,10 +480,10 @@ class BaseDocument {
                 }
             }
         }
-        var proto = Object.getPrototypeOf(this);
-        var protoProps = Object.getOwnPropertyNames(proto);
-
         if (this._extractDocPropertiesOnly !== true) {
+            var proto = Object.getPrototypeOf(this);
+            var protoProps = Object.getOwnPropertyNames(proto);
+
             for (var i = 0; i < protoProps.length; i++) {
                 key = protoProps[i];
                 if (key !== 'constructor' && key !== 'id') {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1649,5 +1649,60 @@ describe('Document', function() {
                 expect(json.children[1]).to.not.be.an.instanceof(Person);
             }).then(done, done);
         });
+
+        it('should serialize data to JSON and ignore methods if configured', function(done) {
+            class Person extends Document {
+                constructor() {
+                    super();
+
+                    this.name = String;
+                    this._extractDocPropertiesOnly = true;
+                }
+
+                static collectionName() {
+                    return 'people';
+                }
+
+                getFoo() {
+                    return 'foo';
+                }
+            }
+
+            var person = Person.create({
+                name: 'Scott'
+            });
+
+            var json = person.toJSON();
+            expect(json).to.have.keys(['_id', 'name']);
+            done();
+        });
+
+        it('should serialize data to JSON and include methods if configured', function(done) {
+            class Person extends Document {
+                constructor() {
+                    super();
+
+                    this.name = String;
+                    this._extractDocPropertiesOnly = false;
+                }
+
+                static collectionName() {
+                    return 'people';
+                }
+
+                getFoo() {
+                    return 'foo';
+                }
+            }
+
+            var person = Person.create({
+                name: 'Scott'
+            });
+
+            var json = person.toJSON();
+            expect(json).to.have.keys(['_id', 'name', 'getFoo']);
+            done();
+        });
+
     });
 });

--- a/test/embedded.test.js
+++ b/test/embedded.test.js
@@ -669,5 +669,49 @@ describe('Embedded', function() {
                 expect(json.address.isPoBox).to.be.equal(false);
             }).then(done, done);
         });
+
+        it('should serialize data to JSON and ignore methods recursively if configured', function(done) {
+            class Address extends EmbeddedDocument {
+                constructor() {
+                    super();
+                    this.street = String;
+                }
+
+                getBar() {
+                    return 'bar';
+                }
+            }
+
+            class Person extends Document {
+                constructor() {
+                    super();
+
+                    this.name = String;
+                    this.address = Address;
+                    this._extractDocPropertiesOnly = true;
+                }
+
+                static collectionName() {
+                    return 'people';
+                }
+
+                getFoo() {
+                    return 'foo';
+                }
+            }
+
+            var person = Person.create({
+                name: 'Scott',
+                address : {
+                    street : 'Bar street'
+                }
+            });
+
+            var json = person.toJSON();
+            expect(json).to.have.keys(['_id', 'name', 'address']);
+            expect(json.address).to.have.keys(['street']);
+
+            done();
+        });
     });
 });


### PR DESCRIPTION
Hi,

I think this project is awesome but I bumped into a small issue which I am creating this PR for.
When extracting a model into JSON it is currently not (easily) possible to exclude methods.

I added an option which can disable the extraction of methods and only extract properties defined in the schema.

Happy to receive feedback.