### PR TITLE
preInit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Hooks can be used not only on `Document` objects, but `EmbeddedDocument` objects
 
 In order to create a hook, you must override a class method. The hooks currently provided, and their corresponding methods, are:
 
+- pre-init: `preInit()`
 - pre-validate: `preValidate()`
 - post-validate: `postValidate()`
 - pre-save: `preSave()`

--- a/lib/base-document.js
+++ b/lib/base-document.js
@@ -107,6 +107,8 @@ class BaseDocument {
      * to override the appropriate hook method below.
      */
 
+    preInit(instance) { }
+
     preValidate() { }
 
     postValidate() { }
@@ -260,11 +262,10 @@ class BaseDocument {
     static create(data) {
         this.createIndexes();
 
-        if (typeof(data) !== 'undefined') {
-            return this._fromData(data);
-        }
-
-        return this._instantiate();
+        let instance = ((typeof(data) !== 'undefined') ? this._fromData(data) : this._instantiate());
+        try { instance.preInit();
+        } catch (e) {};
+        return instance;
     }
 
     static createIndexes() { }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camo",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "A class-based ES6 ODM for Mongo-like databases.",
   "author": {
     "name": "Scott Robinson",

--- a/test/mongoclient.test.js
+++ b/test/mongoclient.test.js
@@ -9,7 +9,7 @@ const validateId = require('./util').validateId;
 
 describe('MongoClient', function() {
 
-    const url = 'mongodb://localhost/camo_test';
+    const url = 'mongodb://localhost:45454/camo_test';
     let database = null;
 
     before(function(done) {

--- a/test/mongoclient.test.js
+++ b/test/mongoclient.test.js
@@ -9,7 +9,7 @@ const validateId = require('./util').validateId;
 
 describe('MongoClient', function() {
 
-    const url = 'mongodb://localhost:45454/camo_test';
+    const url = 'mongodb://localhost/camo_test';
     let database = null;
 
     before(function(done) {


### PR DESCRIPTION
As long as constructor is used for schema describing in Camo, i found it is tricky to perform some init actions without appending needed manually after `.create()` call, so in this patch you may see new `preInit` hook which is called right in `.create()` method before returning of model.
Hook is syncronous. New data instance is passed to hook in first arg.