### PR TITLE
add support for custom adapter registration

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -2,6 +2,7 @@
 
 const NeDbClient = require('./clients/nedbclient');
 const MongoClient = require('./clients/mongoclient');
+let _adapter;
 
 /**
  * Connect to current database
@@ -10,20 +11,36 @@ const MongoClient = require('./clients/mongoclient');
  * @param {Object} options
  * @returns {Promise}
  */
-exports.connect = function(url, options) {
-    if (url.indexOf('nedb://') > -1) {
-        // url example: nedb://path/to/file/folder
-        return NeDbClient.connect(url, options).then(function(db) {
-            global.CLIENT = db;
-            return db;
-        });
-    } else if(url.indexOf('mongodb://') > -1) {
-        // url example: 'mongodb://localhost:27017/myproject'
-        return MongoClient.connect(url, options).then(function(db) {
-            global.CLIENT = db;
-            return db;
-        });
-    } else {
-        return Promise.reject(new Error('Unrecognized DB connection url.'));
+exports.connect = function (url, options) {
+    function handleConnectionSuccessfully(db) {
+        global.CLIENT = db;
+        return db;
     }
+
+    let connect;
+    // We have custom adapter
+    if (_adapter) {
+        connect = NeDbClient.connect(url, options);
+    }
+    else
+        if (url.indexOf('nedb://') > -1) {
+            // url example: nedb://path/to/file/folder
+            connect = NeDbClient.connect(url, options);
+        } else if (url.indexOf('mongodb://') > -1) {
+            // url example: 'mongodb://localhost:27017/myproject'
+            connect = MongoClient.connect(url, options);
+        } else {
+            return Promise.reject(new Error('Unrecognized DB connection url.'));
+        }
+
+    return connect.then(handleConnectionSuccessfully);
 };
+
+/**
+ * Register new adapter instead of using MongoDB and NeDB
+ * We assume that the adapter is valid and inherit DatabaseClient
+ * @param {DatabaseClient} adapter
+ */
+exports.registerAdapter = function handleAdapterRegister(adapter) {
+    _adapter = adapter;
+}


### PR DESCRIPTION
I would like to add functiontion to allow camo to register custom adapter.  It means that I can develop my own adapter (such as CouchDB, PouchDB) without touching camo code.