### PR TITLE
Add support to register custom clients/ fallback to bundled clients

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
 
+const { Clients, getClient } = require('./lib/clients');
+
+exports.Clients = Clients;
+exports.getClient = getClient;
 exports.connect = require('./lib/db').connect;
-exports.getClient = require('./lib/clients').getClient;
 
 exports.Document = require('./lib/document');
 exports.EmbeddedDocument = require('./lib/embedded-document');

--- a/lib/clients/index.js
+++ b/lib/clients/index.js
@@ -1,13 +1,43 @@
 'use strict';
 
-const assertConnected = function(db) {
-    if (db === null || db === undefined) {
-        throw new Error('You must first call \'connect\' before loading/saving documents.');
+const DatabaseClient = require('./client');
+
+var clients = {};
+
+class Clients {
+    static register(type, client) {
+        if (!DatabaseClient.prototype.isPrototypeOf(client.prototype))
+            throw new TypeError(`Client must derive from 'DatabaseClient'`);
+        clients[type] = client;
     }
-};
+
+    static unregister(type) {
+        clients[type] = undefined;
+    }
+
+    static get(type) {
+        if (!clients.hasOwnProperty(type))
+            this.registerDefaultClients(type);
+        return clients[type];
+    }
+
+    static registerDefaultClients(type) {
+        switch (type) {
+            case 'nedb':
+                this.register(type, require('./nedbclient'));
+                break;
+            case 'mongodb':
+                this.register(type, require('./mongoclient'));
+                break;
+        }
+    }
+}
+
+exports.Clients = Clients;
 
 exports.getClient = function() {
     const client = global.CLIENT;
-    assertConnected(client);
+    if (client === null || client === undefined)
+        throw new Error('You must first call \'connect\' before loading/saving documents.');
     return client;
 };

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const NeDbClient = require('./clients/nedbclient');
-const MongoClient = require('./clients/mongoclient');
+const { Clients } = require('./clients');
 
 /**
  * Connect to current database
@@ -11,19 +10,17 @@ const MongoClient = require('./clients/mongoclient');
  * @returns {Promise}
  */
 exports.connect = function(url, options) {
-    if (url.indexOf('nedb://') > -1) {
-        // url example: nedb://path/to/file/folder
-        return NeDbClient.connect(url, options).then(function(db) {
-            global.CLIENT = db;
-            return db;
-        });
-    } else if(url.indexOf('mongodb://') > -1) {
-        // url example: 'mongodb://localhost:27017/myproject'
-        return MongoClient.connect(url, options).then(function(db) {
-            global.CLIENT = db;
-            return db;
-        });
-    } else {
+    let index = url.indexOf('://');
+    if (index <= 0)
         return Promise.reject(new Error('Unrecognized DB connection url.'));
-    }
+
+    let type = url.slice(0, index);
+    let client = Clients.get(type);
+    if (client === null || client === undefined)
+        return Promise.reject(new Error(`No Client registered for '${type}'`));
+
+    return client.connect(url, options).then(function(db) {
+        global.CLIENT = db;
+        return db;
+    });
 };


### PR DESCRIPTION
Step toward modularizing clients - #62 
Custom clients are used by changing the protocol of the connection string.