### PR TITLE
Remove $setOnInsert

### DIFF
--- a/lib/clients/mongoclient.js
+++ b/lib/clients/mongoclient.js
@@ -149,12 +149,7 @@ class MongoClient extends DatabaseClient {
         return new Promise(function(resolve, reject) {
             const db = that._mongo.collection(collection);
 
-            let update = values;
-            if (options.upsert) {
-                update = { $setOnInsert: update };
-            } else {
-                update = { $set: update };
-            }
+            let update = { $set: values };
 
             db.findOneAndUpdate(query, update, options, function(error, result) {
                 if (error) return reject(error);


### PR DESCRIPTION
I had to remove $setOnInsert from MongoClient because that would cause updates to never work.

As stated here: https://docs.mongodb.com/manual/reference/operator/update/setOnInsert/

```If an update operation with upsert: true results in an insert of a document, then $setOnInsert assigns the specified values to the fields in the document. If the update operation does not result in an insert, $setOnInsert does nothing.```

Am I missing something?